### PR TITLE
fix: desktop breakpoints broken due to regression in astro-compress

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -15,7 +15,9 @@ export default defineConfig({
     icon(),
     react(),
     sitemap({ filter: (page) => page !== "https://fyralabs.com/thanks/" }),
-    compress(),
+    compress({
+      CSS: false // fixes navbar breakpoints: https://github.com/PlayForm/Compress/issues/640
+    }),
     robotsTxt(),
   ],
 


### PR DESCRIPTION
desktop breakpoints are broken in newer versions of astro-compress, css compression isnt required since vite already does this so disabling it should fix

https://github.com/PlayForm/Compress/issues/640